### PR TITLE
Containerize React front end and integrate into docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,13 @@ services:
       - db
     ports:
       - 8080:8080
+
+  frontend:
+    build: "orgchart"
+    restart: always
+    env_file:
+      - .env
+    depends_on:
+      - db
+    ports:
+      - 8081:8080

--- a/orgchart/.gitignore
+++ b/orgchart/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/orgchart/Dockerfile
+++ b/orgchart/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1 - Build React App
+FROM node:18-alpine as build
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json .
+RUN npm ci
+
+COPY . ./
+RUN npm run build
+
+# Stage 2 - Serve the built app with nginx
+# Pin the minor version
+FROM nginx:1.23-alpine
+
+
+# Replaced the external nginx.conf with this embeded one
+# COPY nginx.conf /etc/nginx/conf.d/default.conf
+RUN echo -e "server {\n\
+    listen 8080;\n\
+    server_name localhost;\n\
+    root /usr/share/nginx/html;\n\
+    index index.html;\n\
+    location / {\n\
+        try_files \$uri /index.html;\n\
+    }\n\
+}" > /etc/nginx/conf.d/default.conf
+
+COPY --from=build /app/build /usr/share/nginx/html
+
+EXPOSE 8080
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This should just work (locally):
```
docker compose down
docker compose build
docker compose up -d
docker compose logs -f
```

We'll see how we integrate this into GCP/k8s later

- Luc's CRA React front end - is built and put into an nginx static server
- integrated into `docker-compose.yml`

New orgchart front end available locally at <http://localhost:8081/>